### PR TITLE
Experiment: try to leverage the existing null buffer on regex_replace

### DIFF
--- a/datafusion/physical-expr/src/regex_expressions.rs
+++ b/datafusion/physical-expr/src/regex_expressions.rs
@@ -22,7 +22,8 @@
 //! Regex expressions
 
 use arrow::array::{
-    new_null_array, Array, ArrayRef, GenericStringArray, OffsetSizeTrait,
+    new_null_array, Array, ArrayData, ArrayRef, BufferBuilder, GenericStringArray,
+    OffsetSizeTrait,
 };
 use arrow::compute;
 use datafusion_common::{DataFusionError, Result};
@@ -254,13 +255,41 @@ fn _regexp_replace_static_pattern_replace<T: OffsetSizeTrait>(
     // with rust ones.
     let replacement = regex_replace_posix_groups(replacement);
 
-    let result = string_array
-        .iter()
-        .map(|string| {
-            string.map(|string| re.replacen(string, limit, replacement.as_str()))
-        })
-        .collect::<GenericStringArray<T>>();
-    Ok(Arc::new(result) as ArrayRef)
+    // We are going to create the underlying string buffer from its parts
+    // to be able to re-use the existing null buffer for sparse arrays.
+    let mut vals = BufferBuilder::<u8>::new({
+        let offsets = string_array.value_offsets();
+        (offsets[string_array.len()] - offsets[0])
+            .to_usize()
+            .unwrap()
+    });
+    let mut new_offsets = BufferBuilder::<T>::new(string_array.len() + 1);
+    new_offsets.append(T::zero());
+
+    string_array.iter().for_each(|val| {
+        if let Some(val) = val {
+            let result = re.replacen(val, limit, replacement.as_str());
+            vals.append_slice(&result.as_bytes());
+        }
+        new_offsets.append(T::from_usize(vals.len()).unwrap());
+    });
+
+    let data = unsafe {
+        ArrayData::new_unchecked(
+            GenericStringArray::<T>::DATA_TYPE,
+            string_array.len(),
+            None,
+            string_array
+                .data_ref()
+                .null_buffer()
+                .map(|b| b.bit_slice(string_array.offset(), string_array.len())),
+            0,
+            vec![new_offsets.finish(), vals.finish()],
+            vec![],
+        )
+    };
+    let result_array = GenericStringArray::<T>::from(data);
+    Ok(Arc::new(result_array) as ArrayRef)
 }
 
 /// Determine which implementation of the regexp_replace to use based


### PR DESCRIPTION
Data generator:
```py
import pandas
import random

# %20 real data, %80 null
SPARSE_CONFIG = 0.2

SAMPLE_SIZE = 1_000_000
SAMPLE_FACTOR = 100

def random_url() -> str:
    if random.uniform(0, 1) <= SPARSE_CONFIG:
        return (
            random.choice(["http", "https", "grpc", ""])
            + random.choice(["://", ""])
            + random.choice(["google", "facebook", "random", ""])
            + random.choice([".com", ".org", ".net", ""])
        )


data = [random_url() for _ in range(SAMPLE_SIZE)] * SAMPLE_FACTOR
df = pandas.DataFrame({"url": data})
df.to_parquet("test.parquet")
```

Query:
```
EXPLAIN ANALYZE
select REGEXP_REPLACE(url, '^https?://(?:www.)?([^/]+)/.*$', '1') FROM records;
```